### PR TITLE
Auto bump MDC Web deps to 14.0.0-canary.f81fb1d23.0

### DIFF
--- a/packages/layout-grid/package.json
+++ b/packages/layout-grid/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@material/layout-grid": ">=13.0.0",
+    "@material/layout-grid": "=14.0.0-canary.f81fb1d23.0",
     "@material/mwc-base": "^0.25.3",
     "lit": "^2.0.2",
     "tslib": "^2.3.1"


### PR DESCRIPTION
This PR was auto generated by the bump-mdc-deps GitHub action.